### PR TITLE
Make default install non-interactive

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   command:
     description: 'Composer command to run'
     required: true
-    default: install
+    default: install --no-interaction
 outputs:
   time:
     description: 'The time the action was run'


### PR DESCRIPTION
Composer should not ask interactive questions in the non-interactive session of GitHub Actions.

With the `--no-interaction` flag `composer install` would either proceed with recommended approach or issue a warning instead of hanging the build waiting for input.