### PR TITLE
Example contains an invalid input

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ jobs:
     - name: Install dependencies
       uses: php-actions/composer@v2
       with:
-        suggestions: yes
+        suggest: yes
         dev: no
         args: --profile --ignore-platform-reqs
 ```


### PR DESCRIPTION
The current example for allowing **suggestions** is broken and generates the following warning:

`##[warning]Unexpected input(s) 'suggestions', valid inputs are ['entryPoint', 'args', 'command', 'interaction', 'suggest', 'dev', 'progress', 'quiet', 'ssh_key', 'ssh_key_pub', 'ssh_domain']`
