### PR TITLE
Add only_args action argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Any arbitrary arguments can be passed to composer by using the `args` input, how
 + `progress` - Whether to output download progress - yes / no (default no)
 + `quiet` - Whether to suppress all messages - yes / no (default no)
 + `args` - Optional arguments to pass - no constraints (default _empty_)
++ `only_args` - Only run the desired command with this args. Ignoring all other provided arguments(default _empty_)
 
 There are also SSH input available: `ssh_key`, `ssh_key_pub` and `ssh_domain` that are used for depending on private repositories. See below for more information on usage.
 

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,7 @@ runs:
   image: 'Dockerfile'
   env:
     action_command: ${{ inputs.command }}
+    action_only_args: ${{ inputs.only_args }}
     action_interaction: ${{ inputs.interaction }}
     action_suggest: ${{ inputs.suggest }}
     action_dev: ${{ inputs.dev }}

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     required: true
     default: install
 
+  only_args:
+    description: "Only run the desired command with this args. Ignoring all other provided arguments"
+    required: false
+
   interaction:
     description: "Whether to ask any interactive questions. Values: 'yes' or 'no'"
     required: false

--- a/entrypoint
+++ b/entrypoint
@@ -31,74 +31,80 @@ then
 	command_string="$command_string $action_command"
 fi
 
-case "$action_interaction" in
-	yes)
-		# Default behaviour
-	;;
-	no)
-		command_string="$command_string --no-interaction"
-	;;
-	*)
-		echo "Invalid input for action argument: interaction  (must be yes or no)"
-		exit 1
-	;;
-esac
-
-case "$action_suggest" in
-	yes)
-		# Default behaviour
-	;;
-	no)
-		command_string="$command_string --no-suggest"
-	;;
-	*)
-		echo "Invalid input for action argument: suggest (must be yes or no)"
-		exit 1
-	;;
-esac
-
-case "$action_dev" in
-	yes)
-		# Default behaviour
-	;;
-	no)
-		command_string="$command_string --no-dev"
-	;;
-	*)
-		echo "Invalid input for action argument: dev (must be yes or no)"
-		exit 1
-	;;
-esac
-
-case "$action_progress" in
-	yes)
-		# Default behaviour
-	;;
-	no)
-		command_string="$command_string --no-progress"
-	;;
-	*)
-		echo "Invalid input for action argument: progress (must be yes or no)"
-		exit 1
-	;;
-esac
-
-case "$action_quiet" in
-	yes)
-		command_string="$command_string --quiet"
-	;;
-	no)
-		# Default behaviour
-	;;
-	*)
-		echo "Invalid input for action argument: quiet (must be yes or no)"
-		exit 1
-	;;
-esac
-
-if [ -n "$action_args" ]
+if [ ! -n "$action_only_args" ]
 then
-	command_string="$command_string $action_args"
+
+	case "$action_interaction" in
+		yes)
+			# Default behaviour
+		;;
+		no)
+			command_string="$command_string --no-interaction"
+		;;
+		*)
+			echo "Invalid input for action argument: interaction  (must be yes or no)"
+			exit 1
+		;;
+	esac
+
+	case "$action_suggest" in
+		yes)
+			# Default behaviour
+		;;
+		no)
+			command_string="$command_string --no-suggest"
+		;;
+		*)
+			echo "Invalid input for action argument: suggest (must be yes or no)"
+			exit 1
+		;;
+	esac
+
+	case "$action_dev" in
+		yes)
+			# Default behaviour
+		;;
+		no)
+			command_string="$command_string --no-dev"
+		;;
+		*)
+			echo "Invalid input for action argument: dev (must be yes or no)"
+			exit 1
+		;;
+	esac
+
+	case "$action_progress" in
+		yes)
+			# Default behaviour
+		;;
+		no)
+			command_string="$command_string --no-progress"
+		;;
+		*)
+			echo "Invalid input for action argument: progress (must be yes or no)"
+			exit 1
+		;;
+	esac
+
+	case "$action_quiet" in
+		yes)
+			command_string="$command_string --quiet"
+		;;
+		no)
+			# Default behaviour
+		;;
+		*)
+			echo "Invalid input for action argument: quiet (must be yes or no)"
+			exit 1
+		;;
+	esac
+
+	if [ -n "$action_args" ]
+	then
+		command_string="$command_string $action_args"
+	fi
+else
+	command_string="$command_string $action_only_args"
 fi
 
 echo "Command: $command_string"


### PR DESCRIPTION
Using the `php-actions/composer@v2` action for other commands than `install` or `update` will currently make it hard configuring the desired action.

To e.g. call the `dump-autoload` command it is currently necessary to "enable" some options so that they won't be appended to the final composer call. (and fail otherwise because they aren't supported by some commands)
Like so:

```yaml
            -  uses: php-actions/composer@v2
                with:
                    command: dump-autoload
                    dev: no
                    suggest: yes # We need to set this setting because --no-suggest will be appended otherwise and the command will fail
                    progress: yes # We need to set this setting because --no-progress will be appended otherwise and the command will fail
                    args: --classmap-authoritative
```

To easily configure this options I've implemented an `only_args` argument which will disable all other action arguments.
So the desired `dump-autoload` command can be generated by:

```yaml
            -  uses: php-actions/composer@v2
                with:
                    command: dump-autoload
                    only_args: --no-dev --no-interaction --classmap-authoritative
```

