### PR TITLE
Composer docker image version set to 1.10.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:latest
+FROM composer:1.10.15
 
 LABEL repository="https://github.com/php-actions/composer"
 LABEL homepage="https://github.com/php-actions/composer"


### PR DESCRIPTION
Hi,

I faced some problems on my github-flow pipeline today. It was about `composer` last version has a new major version change. It was gone from 1.10.x to 2.x and also it enforce many things for update in terms of dependencies. Anyway my proposal is not about that. I think who are using specific version of this action which is `v1` must be specified for v1.x of composer itself. It makes more sense I think.

Do you agree to delete these tags `v1.0.0` and `v1`  and update those again with this changes?