### PR TITLE
feat: add support for composer oauth token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,10 @@ In the example above, the "key" is passed to the Cache action that consists of a
 Installing private repositories
 -------------------------------
 
-To install from a private repository, SSH authentication must be used. Generate an SSH key pair for this purpose and add it to your private repository's configuration, preferable with only read-only privileges. On Github for instance, this can be done by using [deploy keys][deploy-keys]. 
+To install from a private repository, SSH or OAuth authentication must be used. 
+### SSH Authentication
+
+Generate an SSH key pair for this purpose and add it to your private repository's configuration, preferable with only read-only privileges. On Github for instance, this can be done by using [HTTPS cloning with OAuth tokens][deploy-keys]. 
 
 Add the key pair to your project using  [Github Secrets][secrets], and pass them into the `php-actions/composer` action by using the `ssh_key` and `ssh_key_pub` inputs. If your private repository is stored on another server than github.com, you also need to pass the domain via `ssh_domain`.
 
@@ -173,7 +176,26 @@ jobs:
 ```
 
 There is an example repository available for reference at https://github.com/php-actions/example-composer that uses a private dependency. Check it out for a live working project.
+### OAuth Authentication
 
+Generate an SSH key pair for this purpose and add it to your private repository's configuration, preferable with only read-only privileges. On Github for instance, this can be done by using [deploy keys][deploy-keys]. 
+
+Add the key pair to your project using  [Github Secrets][secrets], and pass them into the `php-actions/composer` action by using the `oauth_token` and `oauth_domain`.
+
+Example yaml, showing how to pass secrets:
+
+```yaml
+jobs:
+  build:
+
+    ...
+
+    - name: Install dependencies
+      uses: php-actions/composer@v2
+      with:
+        oauth_token: ${{ secrets.oauth_token }}
+        oauth_domain: github-oauth.github.com
+```
 ***
 
 If you found this repository helpful, please consider [sponsoring the developer][sponsor].

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,14 @@ inputs:
     description: The domain to gather SSH public keys for (automatic for github.com, gitlab.com, bitbucket.org)
     required: false
 
+  oauth_token:
+    description: The user oauth key to use for private repositories
+    required: false
+
+  oauth_domain:
+    description: The oauth domain to gather oauth_token for
+    required: false
+
   working_dir:
     description: Use the given directory as working directory
     required: false
@@ -85,6 +93,8 @@ runs:
     action_ssh_key: ${{ inputs.ssh_key }}
     action_ssh_key_pub: ${{ inputs.ssh_key_pub }}
     action_ssh_domain: ${{ inputs.ssh_domain }}
+    action_oauth_token: ${{ inputs.oauth_token }}
+    action_oauth_domain: ${{ inputs.oauth_domain }}
     action_working_dir: ${{ inputs.working_dir }}
 
 branding:

--- a/entrypoint
+++ b/entrypoint
@@ -38,6 +38,12 @@ then
 	md5sum /root/.ssh/id_rsa.pub
 fi
 
+if [ -n "$action_oauth_token" ]
+then
+	echo "Storing user oauth token"
+	composer config -g "$action_oauth_domain" "$action_oauth_token" 
+fi
+
 if [ -n "$action_command" ]
 then
 	command_string="$command_string $action_command"


### PR DESCRIPTION
I find the current version impossible with private repositories to use due to some limitations put on me with accessing them.

As a working solution, I am using OAuth token-based authorization [HTTPS cloning with OAuth tokens](https://docs.github.com/en/free-pro-team@latest/developers/overview/managing-deploy-keys#https-cloning-with-oauth-tokens), so there I wanted to propose adding it as a core feature.