### PR TITLE
Add PHP extensions section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,28 @@ jobs:
         version: 1
 ```
 
+
+Including PHP Extensions
+-------------------------------------------
+
+This action includes the [extensions that Composer suggests](https://github.com/composer/composer/blob/master/composer.json#L44) by default. To include additional PHP extensions in your action steps, set the `php_extensions` input with any of the [supported extension names](https://github.com/mlocati/docker-php-extension-installer#supported-php-extensions) separated by spaces.
+
+Example configuration that runs Composer version 2 on PHP version 7.4 with the Redis and Exif extensions enabled:
+
+```yaml
+jobs:
+  build:
+
+    ...
+
+    - name: Install dependencies
+      uses: php-actions/composer@v5
+      with:
+        php_version: 7.4
+        php_extensions: redis exif
+        version: 2
+```
+
 Caching dependencies for faster builds
 --------------------------------------
 


### PR DESCRIPTION
I think this feature, just like switching between PHP version, is pretty useful! But I discovered it only after inspecting the `action.yml` file.

So, I believe including some documentation + an example to README will be useful for other developers too 😄