### PR TITLE
Adds memory limit argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Any arbitrary arguments can be passed to composer by using the `args` input, how
 + `only_args` - Only run the desired command with this args. Ignoring all other provided arguments(default _empty_)
 + `php_version` - Choose which version of PHP you want to use (7.1, 7.2, 7.3, 7.4 or 8.0)
 + `version` - Choose which version of Composer you want to use (1 or 2)
++ `memory_limit` - Sets the composer memory limit - (default _empty_)
 
 There are also SSH input available: `ssh_key`, `ssh_key_pub` and `ssh_domain` that are used for depending on private repositories. See below for more information on usage.
 

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,10 @@ inputs:
     description: Use the given directory as working directory
     required: false
 
+  memory_limit:
+    description: Sets the composer memory limit
+    required: false
+
 outputs:
   full_command:
     description: "The full command passed to docker to run"
@@ -89,6 +93,7 @@ runs:
         ACTION_SSH_KEY_PUB: ${{ inputs.ssh_key_pub }}
         ACTION_SSH_DOMAIN: ${{ inputs.ssh_domain }}
         ACTION_WORKING_DIR: ${{ inputs.working_dir }}
+        ACTION_MEMORY_LIMIT: ${{ inputs.memory_limit }}
       id: composer_run
       run: bash <(curl -s https://raw.githubusercontent.com/php-actions/php-build/330b13bbb1eadd05bbb627477c1549cd7e62e406/php-build.bash) composer \
         && ${{ github.action_path }}/composer-action.bash || { cat ${{ github.workspace }}/output.log ; exit 1; }

--- a/composer-action.bash
+++ b/composer-action.bash
@@ -129,6 +129,11 @@ else
 	command_string="$command_string $ACTION_ONLY_ARGS"
 fi
 
+if [ -n "$ACTION_MEMORY_LIMIT" ]
+then
+  command_string="COMPOSER_MEMORY_LIMIT=$ACTION_MEMORY_LIMIT $command_string"
+fi
+
 echo "Command: $command_string" >> output.log 2>&1
 mkdir -p /tmp/composer-cache
 


### PR DESCRIPTION
For big packages with a lot of dependencies and no composer.lock file you can easily run into an out of memory error. Even with composer 2. So setting the COMPOSER_MEMORY_LIMIT environment variable before the command will make it possible to set a higher memory limit or set -1 to ignore memory