### PR TITLE
[Security Issue] Update README.md to recommend removing auth.json after use

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ It's recommended to use SSH keys for authentication, but sometimes HTTP basic au
 }
 ```
 
-3) Pass this secret to auth.json as a separate action step within your Yaml config:
+3) Pass this secret to auth.json as a separate action step within your Yaml config, and remove auth.json to prevent deploying it:
 
 ```yaml
 jobs:
@@ -221,6 +221,9 @@ jobs:
 
     - name: Install dependencies
       uses: php-actions/composer@v6
+      
+    - name: Remove auth.json file
+      run: rm -f $GITHUB_WORKSPACE/auth.json
 ```
 
 4) Now, any connections Composer makes to Github.com will use your HTTP basic auth credentials, which is essentially the same as being logged in as you, so your private repositories will now be available to Composer.


### PR DESCRIPTION
The auth.json file is created with a Github username and password to be used to authenticate requests from Composer back to Github.  The username and password is recommended to use a personal access token to access private repos.  The auth.json file is created at the root of the repo and if your Github Actions job eventually deploys the contents of this repo to a web accessible server, it will deploy the auth.json file too based on how the example is written.  This update adds a step to remove the auth.json file from the repo after it is used by Composer, preventing sensitive credentials from being deployed in plain text to a potentially public location.