### PR TITLE
Fix typo

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ inputs:
 outputs:
   full_command:
     description: "The full command passed to docker to run"
-    value: ${{ steps.composer_run.putputs.full_command }}
+    value: ${{ steps.composer_run.outputs.full_command }}
 
 runs:
   using: "composite"


### PR DESCRIPTION
There is a typo in the syntax for getting the step output. This pull request fixes that.