### PR TITLE
Use quotes for PHP version numbers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Use the following inputs to run a specific PHP/Composer version combination:
 + `php_version` Available versions: `7.1`, `7.2`, `7.3`, `7.4`, `8.0` (default: `latest` aka: `8.0`)
 + `version` Available versions: `1`, `2` (default: `latest` aka: `2`)
 
+Make sure to put the PHP version number in quotes, otherwise YAML will interpret e.g. `8.0` as `8` which means latest 8.x, not 8.0.
+
 Example configuration that runs Composer version 1 on PHP version 7.1:
 ```yaml
 jobs:
@@ -107,7 +109,7 @@ jobs:
     - name: Install dependencies
       uses: php-actions/composer@v6
       with:
-        php_version: 7.1
+        php_version: "7.1"
         version: 1
 ```
 
@@ -128,7 +130,7 @@ jobs:
     - name: Install dependencies
       uses: php-actions/composer@v6
       with:
-        php_version: 7.4
+        php_version: "7.4"
         php_extensions: redis exif
         version: 2
 ```


### PR DESCRIPTION
The PHP version numbers in the README did not use quotes. This is fine for e.g. 7.1, 7.2, 7.3 and 7.4 but not 8.0, which is interpreted as 8 by YAML and currently resolves to 8.1.1. See [this comment](https://github.com/php-actions/composer/issues/73#issuecomment-1018437745) by @ngrie for an explanation.

Fixes #73

(I suppose a similar fix should be made also for other php-actions modules which use the same mechanism, at least [php-actions/phpunit](https://github.com/php-actions/phpunit))