### PR TITLE
Fix a typo for the incorrect version used

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ jobs:
     ...
 
     - name: Install dependencies
-      uses: php-actions/composer@v7
+      uses: php-actions/composer@v6
       with:
         dev: no
         args: --profile --ignore-platform-reqs


### PR DESCRIPTION
This is to fix a typo for the incorrect version used which is `v7` instead of `v6`