### PR TITLE
Custom ssh port support

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Installing private repositories
 
 To install from a private repository, SSH authentication must be used. Generate an SSH key pair for this purpose and add it to your private repository's configuration, preferable with only read-only privileges. On Github for instance, this can be done by using [deploy keys][deploy-keys]. 
 
-Add the key pair to your project using  [Github Secrets][secrets], and pass them into the `php-actions/composer` action by using the `ssh_key` and `ssh_key_pub` inputs. If your private repository is stored on another server than github.com, you also need to pass the domain via `ssh_domain`.
+Add the key pair to your project using  [Github Secrets][secrets], and pass them into the `php-actions/composer` action by using the `ssh_key` and `ssh_key_pub` inputs. If your private repository is stored on another server than github.com, you also need to pass the domain via `ssh_domain`. If the private repository is configured to use a non-standard SSH port, you can configure this by passing `ssh_port`.
 
 Example yaml, showing how to pass secrets:
 

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,10 @@ inputs:
     description: The domain to gather SSH public keys for (automatic for github.com, gitlab.com, bitbucket.org)
     required: false
 
+  ssh_port:
+    description: Custom port to use in conjunction with ssh_domain
+    required: false
+
   working_dir:
     description: Use the given directory as working directory
     required: false
@@ -92,6 +96,7 @@ runs:
         ACTION_SSH_KEY: ${{ inputs.ssh_key }}
         ACTION_SSH_KEY_PUB: ${{ inputs.ssh_key_pub }}
         ACTION_SSH_DOMAIN: ${{ inputs.ssh_domain }}
+        ACTION_SSH_PORT: ${{ inputs.ssh_port }}
         ACTION_WORKING_DIR: ${{ inputs.working_dir }}
         ACTION_MEMORY_LIMIT: ${{ inputs.memory_limit }}
       id: composer_run

--- a/composer-action.bash
+++ b/composer-action.bash
@@ -33,7 +33,12 @@ then
 
 	if [ -n "$ACTION_SSH_DOMAIN" ]
 	then
-		ssh-keyscan -t rsa "$ACTION_SSH_DOMAIN" >> ~/.ssh/known_hosts
+		if [ -n "$ACTION_SSH_PORT" ]
+		then
+			ssh-keyscan -t rsa -p $ACTION_SSH_PORT "$ACTION_SSH_DOMAIN" >> ~/.ssh/known_hosts
+                else
+			ssh-keyscan -t rsa "$ACTION_SSH_DOMAIN" >> ~/.ssh/known_hosts
+		fi
 	fi
 
 	echo "$ACTION_SSH_KEY" > ~/.ssh/action_rsa


### PR DESCRIPTION
Adds support for using a non-standard ssh port when using a private repository configured with the `ssh_domain` option.