### PR TITLE
fix: use ACTION_CONTAINER_WORKDIR if not empty

### DIFF
--- a/composer-action.bash
+++ b/composer-action.bash
@@ -196,7 +196,7 @@ do
 	fi
 done <<<$(env)
 
-if [ -z "$ACTION_CONTAINER_WORKDIR" ]; then
+if [ -n "$ACTION_CONTAINER_WORKDIR" ]; then
 	container_workdir="${ACTION_CONTAINER_WORKDIR}"
 fi
 


### PR DESCRIPTION
This is currently setting `--workdir` to empty by default 🥴

(`master` seems broken since https://github.com/php-actions/composer/pull/103).

Resolves #107.