### PR TITLE
Docs: Solution for using multiple private repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Installing private repositories
 
 To install from a private repository, SSH authentication must be used. Generate an SSH key pair for this purpose and add it to your private repository's configuration, preferable with only read-only privileges. On Github for instance, this can be done by using [deploy keys][deploy-keys].
 
-If using multiple private repos, Github does not allow to share deploy keys across repos, so you can use a normal user account that has access to all the private repos and [add the SSH key][add-ssh-key-git] to that user.
+If using multiple private repositories, Github does not allow to share deploy keys across repositories, so you can use a normal user account that has access to all the private repositories and [add the SSH key][add-ssh-key-git] to that user.
 
 Add the key pair to your project using  [Github Secrets][secrets], and pass them into the `php-actions/composer` action by using the `ssh_key` and `ssh_key_pub` inputs. If your private repository is stored on another server than github.com, you also need to pass the domain via `ssh_domain`. If the private repository is configured to use a non-standard SSH port, you can configure this by passing `ssh_port`.
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,9 @@ In the example above, the "key" is passed to the Cache action that consists of a
 Installing private repositories
 -------------------------------
 
-To install from a private repository, SSH authentication must be used. Generate an SSH key pair for this purpose and add it to your private repository's configuration, preferable with only read-only privileges. On Github for instance, this can be done by using [deploy keys][deploy-keys]. 
+To install from a private repository, SSH authentication must be used. Generate an SSH key pair for this purpose and add it to your private repository's configuration, preferable with only read-only privileges. On Github for instance, this can be done by using [deploy keys][deploy-keys].
+
+If using multiple private repos, Github does not allow to share deploy keys across repos, so you can use a normal user account that has access to all the private repos and [add the SSH key][add-ssh-key-git] to that user.
 
 Add the key pair to your project using  [Github Secrets][secrets], and pass them into the `php-actions/composer` action by using the `ssh_key` and `ssh_key_pub` inputs. If your private repository is stored on another server than github.com, you also need to pass the domain via `ssh_domain`. If the private repository is configured to use a non-standard SSH port, you can configure this by passing `ssh_port`.
 
@@ -238,5 +240,6 @@ If you found this repository helpful, please consider [sponsoring the developer]
 [php-actions-phpspec]: https://github.com/marketplace/actions/phpspec-php-actions 
 [php-actions-behat]: https://github.com/marketplace/actions/behat-php-actions 
 [deploy-keys]: https://docs.github.com/en/developers/overview/managing-deploy-keys
+[add-ssh-key-git]: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account
 [secrets]: https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets
 [sponsor]: https://github.com/sponsors/g105b


### PR DESCRIPTION
While trying to figure out how to use the action on a composer file with multiple private repos, I luckily stumbled upon the issue 
https://github.com/php-actions/composer/issues/10 where it explained using a normal user instead of deploy keys. That was going to be my next step in testing out a solution and was good to see it confirmed by somebody else who needed this.
There was a mention of updating the doc to mention this, so i thought i'd update it and send a PR over.
Let me know if something doesn't make sense or would like to say something else in it.